### PR TITLE
Install and trust the DHS/Treasury PKI bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ None.
 
 ## Dependencies ##
 
+* [cisagov/ansible-role-dhs-certificates](https://github.com/cisagov/ansible-role-dhs-certificates)
 * [cisagov/ansible-role-venom-certificates](https://github.com/cisagov/ansible-role-venom-certificates)
 
 ## Example Playbook ##

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -37,5 +37,7 @@ galaxy_info:
   role_name: venom_nessus
 
 dependencies:
+  - src: https://github.com/cisagov/ansible-role-dhs-certificates
+    name: dhs_certificates
   - src: https://github.com/cisagov/ansible-role-venom-certificates
     name: venom_certificates

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,6 @@
 ---
+- src: https://github.com/cisagov/ansible-role-dhs-certificates
+  name: dhs_certificates
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
 - src: https://github.com/cisagov/ansible-role-python


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds to this role the installation and trusting (at the OS level) of the DHS/Treasury PKI bundle.

## 💭 Motivation and context ##

These certificates were found to be necessary (in addition to those from [cisagov/ansible-role-venom-certificates](https://github.com/cisagov/ansible-role-venom-certificates)) when testing the COOL/VENOM integration with the VENOM team.

## 🧪 Testing ##

Without these certificates the Tanium clients in the COOL could not communicate with the VENOM Tanium server at all.  With these certificates the SYN packets could be seen travelling from the COOL, through the site-to-site VPN tunnel, and reaching the VENOM Tanium server; however, no ACK packets were received by the COOL systems.

There are still bugs to be fixed, but these certificates are definitely required.

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
