### PR TITLE
Link the agent to the CDM Nessus server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,15 @@ None.
 
 ## Role Variables ##
 
+* `host` - the hostname or IP of the Nessus server.  Required.
 * `install_directory` - the directory where Nessus Agent is installed.
   Defaults to "/opt/nessus_agent".
+* `key` - the secret key used to link the Nessus agent to the Nessus
+  server.  Required.
+* `nessus_groups` - a comma-delimited list of groups to which the host
+  running the Nessus agent should belong.  Required.
+* `port` - the port on which the Nessus server is listening for agent
+  connections.  Required.
 * `third_party_bucket_name` - the name of the AWS S3 bucket where
   third-party software is located.  Defaults to
   "cisa-cool-third-party-production".

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,8 @@
   hosts: all
   roles:
     - role: ansible-role-cdm-nessus-agent
+      vars:
+        hostname: nessus.example.com
+        key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        nessus_groups: good,bad,ugly
+        port: 8080

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,6 +4,7 @@
 import os
 
 # Third-Party Libraries
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -24,3 +25,19 @@ def test_nessus_agent_installed(host):
 def test_nessus_agent_enabled(host):
     """Test that Nessus Agent is enabled."""
     assert host.service("nessusagent").is_enabled
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("groups", "good,bad,ugly"),
+        ("key", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        ("ms_server_ip", "nessus.example.com"),
+        ("ms_server_port", "8080"),
+    ],
+)
+def test_nessus_config(host, key, value):
+    """Test that Nessus Agent is configured."""
+    assert value in host.check_output(
+        f"/opt/nessus_agent/sbin/nessuscli fix --secure --get {key}"
+    )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,3 +62,16 @@
   ansible.builtin.service:
     enabled: yes
     name: nessusagent
+
+- name: Link the Nessus Agent to the CDM Nessus server
+  ansible.builtin.command:
+    argv:
+      - /opt/nessus_agent/sbin/nessuscli
+      - agent
+      - link
+      - --key={{ key }}
+      - --host={{ hostname }}
+      - --port={{ port }}
+      - --groups={{ nessus_groups }}
+      - --offline-install
+    creates: /opt/nessus_agent/var/nessus/master.key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,7 +66,7 @@
 - name: Link the Nessus Agent to the CDM Nessus server
   ansible.builtin.command:
     argv:
-      - /opt/nessus_agent/sbin/nessuscli
+      - "{{ install_directory }}/sbin/nessuscli"
       - agent
       - link
       - --key={{ key }}
@@ -74,4 +74,4 @@
       - --port={{ port }}
       - --groups={{ nessus_groups }}
       - --offline-install
-    creates: /opt/nessus_agent/var/nessus/master.key
+    creates: "{{ install_directory }}/var/nessus/master.key"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds Ansible code to this role that links the Nessus agent to the Nessus server in the CDM environment.

## 💭 Motivation and context ##

The Nessus agent and server will not communicate without this linking in place.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
