### PR TITLE
Remove linking and turn on hostname updating option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ Agent](https://www.tenable.com/products/nessus/nessus-agents),
 specifically for the CISA Continuous Diagnostics and Mitigation (CDM)
 environment.
 
+Note that the command to link the Nessus Agent to the Tenable/Nessus
+server (`nessuscli agent link`) _is not_ run by this Ansible role.  It
+must be run at instance startup via
+[`cloud-init`](https://cloud-init.io/) or a separate Ansible playbook.
+The reason for this is that this Ansible role is used to build AWS
+AMIs, and the linking command generates the Tenable tag _even if run
+with the `--offline-install` option_.  This causes all instances
+generates from that AMI to have the same Tenable tag, and the Tenable
+server cannot handle such duplicate agents.
+
+I would prefer to perform all configuration at AMI build time; but,
+unless Nessus modifies their code to, for example, allow one to
+specify the linking parameters ahead of time we are stuck with this
+substandard solution.
+
 ## Pre-requisites ##
 
 In order to execute the Molecule tests for this Ansible role in GitHub

--- a/README.md
+++ b/README.md
@@ -61,15 +61,8 @@ None.
 
 ## Role Variables ##
 
-* `host` - the hostname or IP of the Nessus server.  Required.
 * `install_directory` - the directory where Nessus Agent is installed.
   Defaults to "/opt/nessus_agent".
-* `key` - the secret key used to link the Nessus agent to the Nessus
-  server.  Required.
-* `nessus_groups` - a comma-delimited list of groups to which the host
-  running the Nessus agent should belong.  Required.
-* `port` - the port on which the Nessus server is listening for agent
-  connections.  Required.
 * `third_party_bucket_name` - the name of the AWS S3 bucket where
   third-party software is located.  Defaults to
   "cisa-cool-third-party-production".

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,8 +3,3 @@
   hosts: all
   roles:
     - role: ansible-role-cdm-nessus-agent
-      vars:
-        hostname: nessus.example.com
-        key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        nessus_groups: good,bad,ugly
-        port: 8080

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,22 +22,20 @@ def test_nessus_agent_installed(host):
     assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')
 
 
-def test_nessus_agent_enabled(host):
-    """Test that Nessus Agent is enabled."""
-    assert host.service("nessusagent").is_enabled
+def test_nessus_agent_enabled_and_started(host):
+    """Test that Nessus Agent is enabled and started."""
+    svc = host.service("nessusagent")
+    assert svc.is_enabled and svc.is_running
 
 
 @pytest.mark.parametrize(
     "key, value",
     [
-        ("groups", "good,bad,ugly"),
-        ("key", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
-        ("ms_server_ip", "nessus.example.com"),
-        ("ms_server_port", "8080"),
+        ("update_hostname", "yes"),
     ],
 )
 def test_nessus_config(host, key, value):
-    """Test that Nessus Agent is configured."""
+    """Test that Nessus Agent non-secure configuration options are as expected."""
     assert value in host.check_output(
-        f"/opt/nessus_agent/sbin/nessuscli fix --secure --get {key}"
+        f"/opt/nessus_agent/sbin/nessuscli fix --get {key}"
     )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,16 +75,3 @@
   tags:
     # There is really no way to make this idempotent
     - molecule-idempotence-notest
-
-- name: Link the Nessus Agent to the CDM Nessus server
-  ansible.builtin.command:
-    argv:
-      - "{{ install_directory }}/sbin/nessuscli"
-      - agent
-      - link
-      - --key={{ key }}
-      - --host={{ hostname }}
-      - --port={{ port }}
-      - --groups={{ nessus_groups }}
-      - --offline-install
-    creates: "{{ install_directory }}/var/nessus/master.key"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,19 @@
   ansible.builtin.service:
     enabled: yes
     name: nessusagent
+    # Required to set the update_hostname option below
+    state: started
+
+- name: Configure the Nessus Agent to send hostname updates
+  ansible.builtin.command:
+    argv:
+      - "{{ install_directory }}/sbin/nessuscli"
+      - fix
+      - --set
+      - update_hostname=yes
+  tags:
+    # There is really no way to make this idempotent
+    - molecule-idempotence-notest
 
 - name: Link the Nessus Agent to the CDM Nessus server
   ansible.builtin.command:


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes two changes:
* It removes the configuration of the data necessary to link the Nessus Agent and CDM Nessus server.
* It turns on a Nessus Agent option to send updates to the CDM Nessus server when the hostname changes.

## 💭 Motivation and context ##

We must remove the configuration of the Nessus Agent link from this Ansible role.  The linking process generates a Tenable Tag, which uniquely identifies the instance to the CDM Nessus server.  If we perform this step here, at AMI build time, then all instances created from that AMI will have identical Tenable Tags.  Nessus cannot handle "duplicated agents" like this, so we need to instead perform the linking via `cloud-init` at first boot.

Configuring the Nessus agent to send updates to the CDM Nessus server when the hostname changes is helpful because our instance's hostnames change when we join them to the FreeIPA domain.  This should make our instances show up in the CDM Nessus as `ipa0`, for example, instead of by the AWS-given hostname that is of the form `ip-10-20-30-40`.

See also:
* cisagov/freeipa-server-tf-module#45
* cisagov/freeipa-server-packer#51
* cisagov/cool-sharedservices-freeipa#36

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also successfully built and deployed a new FreeIPA AMI for our COOL staging environment that includes these changes and verified that
* The FreeIPA instance launched from the new AMI continued to function as before
* The Nessus Agent is properly activated when said instance is spun up

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
