### PR TITLE
Fix incorrect role name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -41,4 +41,4 @@ galaxy_info:
       versions:
         - focal
         - jammy
-  role_name: cdm_nessus
+  role_name: cdm_nessus_agent


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes an incorrect role name.

## 💭 Motivation and context ##

The role name as specified in the role metadata did not agree with the role name prepended to the role variables.

## 🧪 Testing ##

All automated tests pass.  I successfully used these changes in cisagov/freeipa-server-packer#108; the FreeIPA AMI could not be built without these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.