### PR TITLE
Update to latest OS packages and add support for Fedora 38

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,9 +31,7 @@ galaxy_info:
     - name: Fedora
       versions:
         - "37"
-        # The GPG key we have for the Nessus Agent RPM is not accepted
-        # by Fedora 38.
-        # - "38"
+        - "38"
     - name: Kali
       versions:
         - "2023"

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -65,17 +65,15 @@ platforms:
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # The GPG key we have for the Nessus Agent RPM is not accepted by
-  # Fedora 38.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-fedora38-ansible:latest
-  #   name: fedora38-systemd
-  #   platform: amd64
-  #   pre_build_image: yes
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: yes
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2004-ansible:latest

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,7 +21,7 @@ variable "production_objects" {
   description = "The Nessus Agent system package objects inside the production bucket."
   default = [
     "NessusAgent-*",
-    "RPM-GPG-KEY-Tenable-2048",
+    "RPM-GPG-KEY-Tenable-*",
   ]
 }
 
@@ -36,7 +36,7 @@ variable "staging_objects" {
   description = "The Nessus Agent system packages inside the staging bucket."
   default = [
     "NessusAgent-*",
-    "RPM-GPG-KEY-Tenable-2048",
+    "RPM-GPG-KEY-Tenable-*",
   ]
 }
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 # The name of the S3 object corresponding to the Nessus Agent system
 # package
-package_object_name: NessusAgent-8.2.2-debian6_amd64.deb
+package_object_name: NessusAgent-10.4.2-debian10_amd64.deb

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,8 +1,8 @@
 ---
 # The name of the S3 object corresponding to the GPG key for the
 # Nessus Agent system package
-package_gpg_key_object_name: RPM-GPG-KEY-Tenable-2048
+package_gpg_key_object_name: RPM-GPG-KEY-Tenable-4096
 
 # The name of the S3 object corresponding to the Nessus Agent system
 # package
-package_object_name: NessusAgent-8.2.2-fc20.x86_64.rpm
+package_object_name: NessusAgent-10.4.2-fc34.x86_64.rpm

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,4 @@
 ---
 # The name of the S3 object corresponding to the Nessus Agent system
 # package
-package_object_name: NessusAgent-8.2.2-ubuntu1110_amd64.deb
+package_object_name: NessusAgent-10.4.2-ubuntu1404_amd64.deb


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to:
- Use the latest versions of the OS packages
- Support Fedora 38

## 💭 Motivation and context ##

- We may as well use the latest versions of the OS packages as opposed to relying on CDM to update them for us.  (Also our packages were woefully outdated - two major versions behind!)
- Supporting Fedora 38 will help us to update [our FreeIPA server AMI](https://github.com/cisagov/freeipa-server-packer) to use a more recent Fedora 38.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.