### PR TITLE
Update to the latest installer available from Tenable's website

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 # The name of the S3 object corresponding to the Nessus Agent system
 # package
-package_object_name: NessusAgent-10.4.2-debian10_amd64.deb
+package_object_name: NessusAgent-10.5.1-debian10_amd64.deb

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -5,4 +5,4 @@ package_gpg_key_object_name: RPM-GPG-KEY-Tenable-4096
 
 # The name of the S3 object corresponding to the Nessus Agent system
 # package
-package_object_name: NessusAgent-10.4.2-fc34.x86_64.rpm
+package_object_name: NessusAgent-10.5.1-fc38.x86_64.rpm

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,4 @@
 ---
 # The name of the S3 object corresponding to the Nessus Agent system
 # package
-package_object_name: NessusAgent-10.4.2-ubuntu1404_amd64.deb
+package_object_name: NessusAgent-10.5.1-ubuntu1404_amd64.deb


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to use the latest installer available from Tenable's website.

## 💭 Motivation and context ##

It is always good to use the latest installer; in fact, it may be required to do so when cisagov/skeleton-ansible-role#164 and cisagov/skeleton-ansible-role#166 are merged and trickle down via Lineage.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.