### PR TITLE
Enable support for Amazon Linux 2023

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,10 +24,9 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    # We do not have a system package for Amazon Linux 2023.
-    # - name: Amazon Linux
-    #   versions:
-    #     - "2023"
+    - name: Amazon Linux
+      versions:
+        - "2023"
     - name: Debian
       versions:
         - buster

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -10,16 +10,15 @@ dependency:
 driver:
   name: docker
 platforms:
-  # We do not have an installer for Amazon Linux 2023.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-amazonlinux2023-ansible:latest
-  #   name: amazonlinux2023-systemd
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: geerlingguy/docker-debian10-ansible:latest

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,8 @@
+---
+# The name of the S3 object corresponding to the GPG key for the
+# Nessus Agent system package
+package_gpg_key_object_name: RPM-GPG-KEY-Tenable-4096
+
+# The name of the S3 object corresponding to the Nessus Agent system
+# package
+package_object_name: NessusAgent-10.5.1-amzn2.x86_64.rpm


### PR DESCRIPTION
## 🗣 Description ##

This pull request enables support for Amazon Linux 2023.

## 💭 Motivation and context ##

We now have a system package that supports AL2023, so we may as well support it in our Ansible role.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.